### PR TITLE
feat: configurar entorno de pruebas local para click-places

### DIFF
--- a/examples/click-places/index.html
+++ b/examples/click-places/index.html
@@ -6,6 +6,12 @@
     <title>GeoAR.js demo</title>
     <script src='https://aframe.io/releases/0.9.2/aframe.min.js'></script>
     <script src='https://raw.githack.com/jeromeetienne/AR.js/master/aframe/build/aframe-ar.min.js'></script>
+    
+    <!-- Load local components to override/extend AR.js functionality -->
+    <script src="../../src/gps-entity-place.js"></script>
+    <script src="../../src/gps-camera.js"></script>
+    <script src="../../src/gps-camera-debug.js"></script>
+
     <script>
         THREEx.ArToolkitContext.baseURL = 'https://raw.githack.com/jeromeetienne/ar.js/master/three.js/'
     </script>

--- a/examples/click-places/places.js
+++ b/examples/click-places/places.js
@@ -1,57 +1,39 @@
-const loadPlaces = function(coords) {
-    // COMMENT FOLLOWING LINE IF YOU WANT TO USE STATIC DATA AND ADD COORDINATES IN THE FOLLOWING 'PLACES' ARRAY
-    const method = 'api';
 
+const loadPlaces = function(coords) {
+    // Generate 4 points around the user for easy testing
     const PLACES = [
         {
-            name: "Your place name",
+            name: "Test Place North",
             location: {
-                lat: 0, // add here latitude if using static data
-                lng: 0, // add here longitude if using static data
-
+                lat: coords.latitude + 0.0005,
+                lng: coords.longitude,
             }
         },
+        {
+            name: "Test Place South",
+            location: {
+                lat: coords.latitude - 0.0005,
+                lng: coords.longitude,
+            }
+        },
+        {
+            name: "Test Place East",
+            location: {
+                lat: coords.latitude,
+                lng: coords.longitude + 0.0005,
+            }
+        },
+        {
+            name: "Test Place West",
+            location: {
+                lat: coords.latitude,
+                lng: coords.longitude - 0.0005,
+            }
+        }
     ];
-
-    if (method === 'api') {
-        return loadPlaceFromAPIs(coords);
-    }
 
     return Promise.resolve(PLACES);
 };
-
-// getting places from REST APIs
-function loadPlaceFromAPIs(position) {
-    const params = {
-        radius: 300,    // search places not farther than this value (in meters)
-        clientId: 'HZIJGI4COHQ4AI45QXKCDFJWFJ1SFHYDFCCWKPIJDWHLVQVZ',
-        clientSecret: '',
-        version: '20300101',    // foursquare versioning, required but unuseful for this demo
-    };
-
-    // CORS Proxy to avoid CORS problems
-    const corsProxy = 'https://cors-anywhere.herokuapp.com/';
-
-    // Foursquare API
-    const endpoint = `${corsProxy}https://api.foursquare.com/v2/venues/search?intent=checkin
-        &ll=${position.latitude},${position.longitude}
-        &radius=${params.radius}
-        &client_id=${params.clientId}
-        &client_secret=${params.clientSecret}
-        &limit=15
-        &v=${params.version}`;
-    return fetch(endpoint)
-        .then((res) => {
-            return res.json()
-                .then((resp) => {
-                    return resp.response.venues;
-                })
-        })
-        .catch((err) => {
-            console.error('Error with places API', err);
-        })
-};
-
 
 window.onload = () => {
     const scene = document.querySelector('a-scene');


### PR DESCRIPTION
## Configuración de Pruebas Locales
Este PR configura el ejemplo `examples/click-places` para que sea fácilmente testeable en dispositivos móviles sin dependencias de APIs externas.

### Cambios
- **index.html**: Cambiado para usar archivos `src` locales (`gps-camera.js`, `gps-entity-place.js`) en lugar de la versión CDN. Esto permite probar cambios locales en la librería core.
- **places.js**: Reemplazada la lógica de la API de Foursquare (que requiere keys y proxy) con un generador estático que crea 4 puntos de prueba (Norte, Sur, Este, Oeste) relativos a la posición actual del usuario.

### Cómo probar
1. Fusionar este PR.
2. Abrir la URL de GitHub Pages para `examples/click-places/index.html` en un móvil.
3. Aceptar permisos de Cámara/GPS.
4. Verificar que aparecen marcadores alrededor.