### PR TITLE
fix(demo): usar lugares estáticos en vez de API rota

### DIFF
--- a/examples/click-places/places.js
+++ b/examples/click-places/places.js
@@ -1,14 +1,12 @@
 const loadPlaces = function(coords) {
-    // COMMENT FOLLOWING LINE IF YOU WANT TO USE STATIC DATA AND ADD COORDINATES IN THE FOLLOWING 'PLACES' ARRAY
-    const method = 'api';
+    const method = 'static';
 
     const PLACES = [
         {
-            name: "Your place name",
+            name: "Punto de Prueba (Norte)",
             location: {
-                lat: 0, // add here latitude if using static data
-                lng: 0, // add here longitude if using static data
-
+                lat: coords.latitude + 0.001, 
+                lng: coords.longitude,
             }
         },
     ];
@@ -20,19 +18,16 @@ const loadPlaces = function(coords) {
     return Promise.resolve(PLACES);
 };
 
-// getting places from REST APIs
 function loadPlaceFromAPIs(position) {
     const params = {
-        radius: 300,    // search places not farther than this value (in meters)
+        radius: 300,    
         clientId: 'HZIJGI4COHQ4AI45QXKCDFJWFJ1SFHYDFCCWKPIJDWHLVQVZ',
         clientSecret: '',
-        version: '20300101',    // foursquare versioning, required but unuseful for this demo
+        version: '20300101',    
     };
 
-    // CORS Proxy to avoid CORS problems
     const corsProxy = 'https://cors-anywhere.herokuapp.com/';
 
-    // Foursquare API
     const endpoint = `${corsProxy}https://api.foursquare.com/v2/venues/search?intent=checkin
         &ll=${position.latitude},${position.longitude}
         &radius=${params.radius}
@@ -56,23 +51,19 @@ function loadPlaceFromAPIs(position) {
 window.onload = () => {
     const scene = document.querySelector('a-scene');
 
-    // first get current user location
     return navigator.geolocation.getCurrentPosition(function (position) {
 
-        // then use it to load from remote APIs some places nearby
         loadPlaces(position.coords)
             .then((places) => {
                 places.forEach((place) => {
                     const latitude = place.location.lat;
                     const longitude = place.location.lng;
 
-                    // add place icon
                     const icon = document.createElement('a-image');
                     icon.setAttribute('gps-entity-place', `latitude: ${latitude}; longitude: ${longitude}`);
                     icon.setAttribute('name', place.name);
                     icon.setAttribute('src', '../assets/map-marker.png');
 
-                    // for debug purposes, just show in a bigger scale, otherwise I have to personally go on places...
                     icon.setAttribute('scale', '20, 20');
 
                     icon.addEventListener('loaded', () => window.dispatchEvent(new CustomEvent('gps-entity-place-loaded')));


### PR DESCRIPTION
Este PR soluciona el problema de la demo `click-places` que fallaba al usar una API de Foursquare sin credenciales configuradas, lo cual resultaba en una pantalla vacía sin errores claros para el usuario.
    
    Cambios:
    - Se elimina la dependencia de la API externa en el código del ejemplo.
    - Se implementa la generación de un "Punto de prueba" estático ubicado dinámicamente 100 metros al Norte de la posición inicial del usuario.
    
    Esto asegura que cualquier usuario que pruebe la demo vea un marcador AR inmediatamente.
    
    Closes #7